### PR TITLE
Fixes for schedule

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
@@ -522,9 +522,6 @@
                     <item name="required" xsi:type="boolean">false</item>
                     <item name="breakLine" xsi:type="boolean">false</item>
                     <item name="scopeLabel" xsi:type="string">[STORE VIEW]</item>
-                    <item name="imports" xsi:type="array">
-                        <item name="disabled" xsi:type="string">ns = ${ $.ns }, index = custom_use_parent_settings :checked</item>
-                    </item>
                 </item>
             </argument>
             <field name="custom_design_from" sortOrder="230" formElement="date">
@@ -534,9 +531,6 @@
                     </additionalClasses>
                     <dataType>string</dataType>
                     <label translate="true">Schedule Update From</label>
-                    <imports>
-                        <link name="disabled">ns = ${ $.ns }, index = custom_use_parent_settings :checked</link>
-                    </imports>
                 </settings>
             </field>
             <field name="custom_design_to" sortOrder="240" formElement="date">
@@ -547,9 +541,6 @@
                     </additionalClasses>
                     <dataType>string</dataType>
                     <label translate="true">To</label>
-                    <imports>
-                        <link name="disabled">ns = ${ $.ns }, index = custom_use_parent_settings :checked</link>
-                    </imports>
                 </settings>
             </field>
         </container>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #20377: Schedule Update From (Schedule Design Update) not saving When switch store view from admin

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

    1. Go to admin panel
    2. Admin=>Catalog=>Categories=>Navigate any category=>Schedule Design Update
    3. Switch store to "default store view"
    4. Click on checkbox (Checked) and save.


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
